### PR TITLE
Update to latest version of leveldb

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,10 +62,8 @@ module.exports = function(options) {
     sessions.get(sid, function(err, meta) {
       if (err) return cb(false, expiredError)
       var pmeta = JSON.parse(meta)
-      console.log("got meta:", pmeta)
       profiles.get(pmeta.email, function(err, profile) {
         if (err) return cb(false, expiredError)
-        console.log("got profile:", JSON.parse(profile))
         cb (false, JSON.parse(profile))
       })
     })

--- a/index.js
+++ b/index.js
@@ -19,11 +19,11 @@ module.exports = function(options) {
   
   persona.on('create', function (sid, meta) {
     var profile = {email: meta.email}
-    sessions.put(sid, meta, function(err) {
+    sessions.put(sid, JSON.stringify(meta), function(err) {
       if (err) console.log('sessions save error', sid, err.message)
     })
     profiles.get(profile.email, function(err, existingProfile) {
-      profiles.put(profile.email, existingProfile || profile, function(err) {
+      profiles.put(profile.email, existingProfile || JSON.stringify(profile), function(err) {
         if (err) console.log('persona save error', profile.email, err.message)
       })
     })
@@ -61,9 +61,12 @@ module.exports = function(options) {
     if (!sid) return cb(false, { loggedOut: true })
     sessions.get(sid, function(err, meta) {
       if (err) return cb(false, expiredError)
-      profiles.get(meta.email, function(err, profile) {
+      var pmeta = JSON.parse(meta)
+      console.log("got meta:", pmeta)
+      profiles.get(pmeta.email, function(err, profile) {
         if (err) return cb(false, expiredError)
-        cb (false, profile)
+        console.log("got profile:", JSON.parse(profile))
+        cb (false, JSON.parse(profile))
       })
     })
   }

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
   "dependencies": {
     "persona-id": "git://github.com/maxogden/persona-id.git#cookie-method",
     "corser": "~1.2.0",
-    "leveldown": "~0.5.0",
+    "leveldown": "~0.7.0",
     "ecstatic": "~0.4.5",
-    "level": "~0.12.0",
-    "level-sublevel": "~4.8.3"
+    "level": "~0.14.0",
+    "level-sublevel": "~5.0.1"
   },
   "devDependencies": {
     "browser-request": "~0.2.1",
-    "browserify": "~2.18.1",
+    "browserify": "~2.28.0",
     "ecstatic": "~0.4.5"
   }
 }


### PR DESCRIPTION
This is a host of compatibility fixes/tweak that make doorknob compatible with the latest leveldb.
