### PR TITLE
typo: default db location in readme.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ Default options:
 ```js
 {
   valueEncoding: 'json',
-  location: path.join(os.tmpdir(), 'doorknob.db'),
+  location: path.join(os.tmpdir(), 'data.leveldb'),
   db: levelup(options.location, options),
   audience: 'http://localhost:8080',
   devMode: false // used to develop offline, returns a fake session


### PR DESCRIPTION
doorknob.db -> data.leveldb

I wonder if anyone else is keen on using something like [visionmedia/mdconf](https://github.com/visionmedia/mdconf) for things like default settings, making the info in the readme becomes 'live'. Is that a bad idea?
